### PR TITLE
Fix SVG download URL resolution for IE/Edge

### DIFF
--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -53,7 +53,11 @@ var fileSaver = function(url, name) {
 
         // IE 10+ (native saveAs)
         if(typeof navigator !== 'undefined' && navigator.msSaveBlob) {
-            navigator.msSaveBlob(new Blob([url]), name);
+            // At this point we are only dealing with a SVG encoded as
+            // a data URL (since IE only supports SVG)
+            var encoded = url.split(/^data:image\/svg\+xml,/)[1];
+            var svg = decodeURIComponent(encoded);
+            navigator.msSaveBlob(new Blob([svg]), name);
             resolve(name);
         }
 


### PR DESCRIPTION
Extracts and decodes SVG source code from the generated data URL before saving SVG files using MS IE/Edge.

Without this change, the downloaded SVG files contain invalid data (the literal encoded data URL) instead of the original SVG source code.