### PR TITLE
Support non-SVG snapshots when using MS Edge

### DIFF
--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -34,15 +34,6 @@ function downloadImage(gd, opts) {
             reject(new Error('Snapshotting already in progress.'));
         }
 
-        // see comments within svgtoimg for additional
-        //   discussion of problems with IE
-        //   can now draw to canvas, but CORS tainted canvas
-        //   does not allow toDataURL
-        //   svg format will work though
-        if(Lib.isIE() && opts.format !== 'svg') {
-            reject(new Error('Sorry IE does not support downloading from canvas. Try {format:\'svg\'} instead.'));
-        }
-
         gd._snapshotInProgress = true;
         var promise = toImage(gd, opts);
 


### PR DESCRIPTION
Allows non-SVG snapshots when using MS Edge (but not IE).

Adds:
* special handling of base64-encoded image data when constructing the blob in `filesaver.js`
* `try`/`catch` around `canvas.toDataURL` invocation in `svgtoimg.js` and specially handles `SecurityError` (only anticipated in IE but not Edge); also catches generic errors

Removes:
* IE non-SVG format guard in `download.js`
* IE non-SVG format guard in `svgtoimg.js`